### PR TITLE
[PLATFORM-1885] - Update Sentry setup as recommended in koa docs

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,11 +36,10 @@ if (SENTRY_DSN) {
   Sentry.init({
     dsn: SENTRY_DSN,
   })
-  // The request handler must be the first middleware on the app
-  app.use(Sentry.Handlers.requestHandler())
 
-  // The error handler must be before any other error middleware
-  app.use(Sentry.Handlers.errorHandler())
+  app.on('error', err => {
+    Sentry.captureException(err)
+  })
 }
 
 // Make sure we're using SSL


### PR DESCRIPTION
Previous setup was taken from Kaws looks like is express specific and seems to have been causing the error:
https://docs.sentry.io/platforms/node/express/

The setup is simpler for Koa:
https://sentry.io/for/koa/
