### PR TITLE
fix: replace docker-compose extends keyword with Jinja2 template

### DIFF
--- a/hokusai/build.yml
+++ b/hokusai/build.yml
@@ -2,5 +2,4 @@
 version: '2'
 services:
   volley:
-    build:
-      context: ../
+{% include 'templates/docker-compose-service.yml.j2' %}

--- a/hokusai/development.yml
+++ b/hokusai/development.yml
@@ -7,8 +7,6 @@ services:
       - NODE_ENV=development
       - PORT=5500
       - STATSD_HOST=docker.for.mac.localhost
-    extends:
-      file: build.yml
-      service: volley
+{% include 'templates/docker-compose-service.yml.j2' %}
     ports:
       - 5500:5500

--- a/hokusai/templates/docker-compose-service.yml.j2
+++ b/hokusai/templates/docker-compose-service.yml.j2
@@ -1,0 +1,2 @@
+    build:
+      context: ../

--- a/hokusai/test.yml
+++ b/hokusai/test.yml
@@ -4,6 +4,4 @@ services:
   volley:
     command: yarn test
     env_file: ../.env.test
-    extends:
-      file: build.yml
-      service: volley
+{% include 'templates/docker-compose-service.yml.j2' %}


### PR DESCRIPTION
Required for Docker Compose v3 / Hokusai >= v0.5.12 compatibility