### PR TITLE
fix: increase max request body size to support Calibre webhooks

### DIFF
--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -126,6 +126,8 @@ apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: volley
+  annotations:
+    nginx.ingress.kubernetes.io/proxy-body-size: "3m"
 spec:
   ingressClassName: nginx
   rules:

--- a/hokusai/staging.yml
+++ b/hokusai/staging.yml
@@ -126,6 +126,8 @@ apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: volley
+  annotations:
+    nginx.ingress.kubernetes.io/proxy-body-size: "3m"
 spec:
   ingressClassName: nginx
   rules:


### PR DESCRIPTION
We stopped recording Calibre performance metrics back in February. I re-enabled [the Calibre webhook](https://calibreapp.com/teams/artsy/artsy-net/settings/integrations) and attempted a snapshot, but saw errors receiving the metrics:

```
[error] 623#623: *331893043 client intended to send too large body: 1449217 bytes, client: 52.90.104.147, server: volley.artsy.net, request: "POST /webhook HTTP/1.1", host: "volley.artsy.net"
```

This increases the max allowed request size from nginx's default of 1 MB, as per [docs](https://github.com/kubernetes/ingress-nginx/blob/main/docs/user-guide/nginx-configuration/annotations.md#custom-max-body-size).

