### PR TITLE
fix: Increase allowed request size to support Calibre webhooks

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -139,7 +139,7 @@ router
   })
 
 app.use(cors())
-app.use(koaBody())
+app.use(koaBody({ "jsonLimit": "3mb" }))
 app.use(router.routes())
 
 export const server = app.listen(PORT, () => console.log(`Listening on port ${PORT}`))


### PR DESCRIPTION
Follows up https://github.com/artsy/volley/pull/148, which did resolve the nginx constraint, but revealed that `koaBody` _also_ imposes a 1 MB limit by default.