### PR TITLE
fix: use k8s node IP for targeting datadog agent

### DIFF
--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -36,13 +36,13 @@ spec:
         - name: STATSD_HOST
           valueFrom:
             fieldRef:
-              fieldPath: spec.nodeName
+              fieldPath: status.hostIP
         - name: STATSD_PORT
           value: '8125'
         - name: DATADOG_AGENT_HOSTNAME
           valueFrom:
             fieldRef:
-              fieldPath: spec.nodeName
+              fieldPath: status.hostIP
         - name: DD_VERSION
           valueFrom:
             fieldRef:

--- a/hokusai/staging.yml
+++ b/hokusai/staging.yml
@@ -36,13 +36,13 @@ spec:
         - name: STATSD_HOST
           valueFrom:
             fieldRef:
-              fieldPath: spec.nodeName
+              fieldPath: status.hostIP
         - name: STATSD_PORT
           value: '8125'
         - name: DATADOG_AGENT_HOSTNAME
           valueFrom:
             fieldRef:
-              fieldPath: spec.nodeName
+              fieldPath: status.hostIP
         - name: DD_VERSION
           valueFrom:
             fieldRef:


### PR DESCRIPTION
https://artsy.slack.com/archives/CA8SANW3W/p1666310574697709

Seeing 50-150 [trace.dns.lookup.hits](https://app.datadoghq.com/apm/services/volley.dns/operations/dns.lookup/resources?env=production&resources=qson%3A%28data%3A%28visible%3A%21t%2Chits%3A%28selected%3Atotal%29%2Cerrors%3A%28selected%3Atotal%29%2Clatency%3A%28selected%3Ap99%29%2CtopN%3A%215%29%2Cversion%3A%210%29&summary=qson%3A%28data%3A%28visible%3A%21t%2Cerrors%3A%28selected%3Acount%29%2Chits%3A%28selected%3Aversion_rate%29%2Clatency%3A%28selected%3Alatency%2Cslot%3A%28agg%3A75%29%2Cdistribution%3A%28isLogScale%3A%21f%29%29%2Csublayer%3A%28slot%3A%28layers%3Aservice%29%2Cselected%3Apercentage%29%29%2Cversion%3A%211%29&topGraphs=latency%3Alatency%2Cerrors%3Acount%2Chits%3Acount&start=1666290333408&end=1666376733408&paused=false) per second. A debug in a prod `volley-web` container shows continuous dns queries:

```
kubectl --context production alpha debug -it volley-web-569b8dc699-26lqr --image=nicolaka/netshoot --target=volley-web

 volley-web-569b8dc699-26lqr  ~  tcpdump -nn dst port 53
tcpdump: verbose output suppressed, use -v[v]... for full protocol decode
listening on eth0, link-type EN10MB (Ethernet), snapshot length 262144 bytes
15:29:24.108286 IP 100.110.87.196.33467 > 100.64.0.10.53: 2218+ A? ip-10-0-4-148.ec2.internal. (44)
15:29:24.108831 IP 100.110.87.196.53721 > 100.64.0.10.53: 28193+ A? ip-10-0-4-148.ec2.internal. (44)
15:29:24.108907 IP 100.110.87.196.45322 > 100.64.0.10.53: 45119+ A? ip-10-0-4-148.ec2.internal. (44)

# capture ran for 10 seconds
 volley-web-569b8dc699-26lqr  ~  tcpdump -G 10 -W 1 -w /tmp/test.pcap -nn dst port 53
tcpdump: listening on eth0, link-type EN10MB (Ethernet), snapshot length 262144 bytes
Maximum file limit reached: 1
456 packets captured
486 packets received by filter <--- ~50 pkts/sec
0 packets dropped by kernel
```
This is likely dogstatsd client resolving `STATSD_HOST` every time it logs a metric to dd-agent.

In hokusai spec, `STATSD_HOST` (and `DATADOG_AGENT_HOSTNAME`) is set to `fieldPath: spec.nodeName` which becomes the k8s node's EC2 dns name, `ip-10-0-4-148.ec2.internal` in the above example. dogstatsd must resolve it to an IP address.

Let's try setting the vars to `status.hostIP` (k8s node IP) so that dogstatsd doesn't have to resolve DNS.

If this works, I plan to change our [template](https://github.com/artsy/artsy-hokusai-templates/blob/main/nodejs/hokusai/production.yml.j2#L42) to `status.hostIP`.