### PR TITLE
test: fix container reference for hokusai v1.2.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,13 +28,13 @@ workflows:
             - run: mkdir -p ./coverage ./reports
             - run:
                 name: Copy coverage artifacts
-                command: docker cp hokusai_volley_1:/app/coverage ./
+                command: docker cp hokusai-volley-1:/app/coverage ./
                 when: always
             - codecov/upload:
                 file: ./coverage/lcov.info
             - run:
                 name: Copy coverage reports
-                command: docker cp hokusai_volley_1:/app/reports ./
+                command: docker cp hokusai-volley-1:/app/reports ./
                 when: always
             - store_test_results:
                 path: ./reports


### PR DESCRIPTION
Similar to https://github.com/artsy/volt/pull/6999. The new `No such container:path: hokusai_..._1:/app/rspec` error appears related to [hokusai's v1.2.0 release](https://github.com/artsy/hokusai/pull/364) and specifically its docker-compose upgrade.